### PR TITLE
support libraries must use the same version specification

### DIFF
--- a/Screencast/MovieManager/app/build.gradle
+++ b/Screencast/MovieManager/app/build.gradle
@@ -38,8 +38,8 @@ dependencies {
     compile 'com.android.support:support-v4:25.1.1'
     testCompile 'junit:junit:4.12'
 
-    compile 'com.android.support:recyclerview-v7:25.1.0'
-    compile 'com.android.support:cardview-v7:25.1.0'
+    compile 'com.android.support:recyclerview-v7:25.1.1'
+    compile 'com.android.support:cardview-v7:25.1.1'
 
     compile 'com.jakewharton:butterknife:8.4.0'
     compile 'com.squareup.picasso:picasso:2.5.2'


### PR DESCRIPTION
All com.android.support libraries must use the exact same version specification